### PR TITLE
Upgrade gh-aw to v0.42.0

### DIFF
--- a/.github/agents/agentic-workflows.agent.md
+++ b/.github/agents/agentic-workflows.agent.md
@@ -17,12 +17,17 @@ This is a **dispatcher agent** that routes your request to the appropriate speci
 - **Upgrading workflows**: Routes to `upgrade-agentic-workflows` prompt
 - **Creating shared components**: Routes to `create-shared-agentic-workflow` prompt
 
+Workflows may optionally include:
+
+- **Project tracking / monitoring** (GitHub Projects updates, status reporting)
+- **Orchestration / coordination** (one workflow assigning agents or dispatching and coordinating other workflows)
+
 ## Files This Applies To
 
 - Workflow files: `.github/workflows/*.md` and `.github/workflows/**/*.md`
 - Workflow lock files: `.github/workflows/*.lock.yml`
 - Shared components: `.github/workflows/shared/*.md`
-- Configuration: `.github/aw/github-agentic-workflows.md`
+- Configuration: https://github.com/github/gh-aw/blob/v0.42.0/.github/aw/github-agentic-workflows.md
 
 ## Problems This Solves
 
@@ -44,7 +49,7 @@ When you interact with this agent, it will:
 ### Create New Workflow
 **Load when**: User wants to create a new workflow from scratch, add automation, or design a workflow that doesn't exist yet
 
-**Prompt file**: `.github/aw/create-agentic-workflow.md`
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.42.0/.github/aw/create-agentic-workflow.md
 
 **Use cases**:
 - "Create a workflow that triages issues"
@@ -54,7 +59,7 @@ When you interact with this agent, it will:
 ### Update Existing Workflow  
 **Load when**: User wants to modify, improve, or refactor an existing workflow
 
-**Prompt file**: `.github/aw/update-agentic-workflow.md`
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.42.0/.github/aw/update-agentic-workflow.md
 
 **Use cases**:
 - "Add web-fetch tool to the issue-classifier workflow"
@@ -64,7 +69,7 @@ When you interact with this agent, it will:
 ### Debug Workflow  
 **Load when**: User needs to investigate, audit, debug, or understand a workflow, troubleshoot issues, analyze logs, or fix errors
 
-**Prompt file**: `.github/aw/debug-agentic-workflow.md`
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.42.0/.github/aw/debug-agentic-workflow.md
 
 **Use cases**:
 - "Why is this workflow failing?"
@@ -74,7 +79,7 @@ When you interact with this agent, it will:
 ### Upgrade Agentic Workflows
 **Load when**: User wants to upgrade workflows to a new gh-aw version or fix deprecations
 
-**Prompt file**: `.github/aw/upgrade-agentic-workflows.md`
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.42.0/.github/aw/upgrade-agentic-workflows.md
 
 **Use cases**:
 - "Upgrade all workflows to the latest version"
@@ -84,19 +89,43 @@ When you interact with this agent, it will:
 ### Create Shared Agentic Workflow
 **Load when**: User wants to create a reusable workflow component or wrap an MCP server
 
-**Prompt file**: `.github/aw/create-shared-agentic-workflow.md`
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.42.0/.github/aw/create-shared-agentic-workflow.md
 
 **Use cases**:
 - "Create a shared component for Notion integration"
 - "Wrap the Slack MCP server as a reusable component"
 - "Design a shared workflow for database queries"
 
+### Orchestration and Delegation
+
+**Load when**: Creating or updating workflows that coordinate multiple agents or dispatch work to other workflows
+
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.42.0/.github/aw/orchestration.md
+
+**Use cases**:
+- Assigning work to AI coding agents
+- Dispatching specialized worker workflows
+- Using correlation IDs for tracking
+- Orchestration design patterns
+
+### GitHub Projects Integration
+
+**Load when**: Creating or updating workflows that manage GitHub Projects v2
+
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.42.0/.github/aw/projects.md
+
+**Use cases**:
+- Tracking items and fields with update-project
+- Posting periodic run summaries
+- Creating new projects
+- Projects v2 authentication and configuration
+
 ## Instructions
 
 When a user interacts with you:
 
 1. **Identify the task type** from the user's request
-2. **Load the appropriate prompt** using `.github/aw/<prompt-name>.md`
+2. **Load the appropriate prompt** from the GitHub repository URLs listed above
 3. **Follow the loaded prompt's instructions** exactly
 4. **If uncertain**, ask clarifying questions to determine the right prompt
 
@@ -105,9 +134,6 @@ When a user interacts with you:
 ```bash
 # Initialize repository for agentic workflows
 gh aw init
-
-# Create a new workflow
-gh aw new <workflow-name>
 
 # Compile workflows
 gh aw compile [workflow-name]
@@ -133,7 +159,7 @@ gh aw compile --validate
 
 ## Important Notes
 
-- Always reference the instructions file at `.github/aw/github-agentic-workflows.md` for complete documentation
+- Always reference the instructions file at https://github.com/github/gh-aw/blob/v0.42.0/.github/aw/github-agentic-workflows.md for complete documentation
 - Use the MCP tool `agentic-workflows` when running in GitHub Copilot Cloud
 - Workflows must be compiled to `.lock.yml` files before running in GitHub Actions
 - Follow security best practices: minimal permissions, explicit network access, no template injection

--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -15,11 +15,6 @@
       "version": "v8",
       "sha": "ed597411d8f924073f98dfc5c65a23a2325f34cd"
     },
-    "github/gh-aw/actions/setup@v0.37.27": {
-      "repo": "github/gh-aw/actions/setup",
-      "version": "v0.37.27",
-      "sha": "a5ea9beb1b6775cad8a63b18cf72a6efd6f7c044"
-    },
     "github/gh-aw/actions/setup@v0.42.0": {
       "repo": "github/gh-aw/actions/setup",
       "version": "v0.42.0",

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,8 +13,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Install gh-aw extension
-      uses: github/gh-aw/actions/setup-cli@v0.37.20
+      uses: github/gh-aw/actions/setup-cli@v0.42.0
       with:
-        version: v0.37.20
+        version: v0.42.0
     - name: Verify gh-aw installation
       run: gh aw version


### PR DESCRIPTION
## Summary

- Updated `github/gh-aw/actions/setup` from v0.37.27 to v0.42.0
- Updated agent and prompt files
- Updated actions-lock.json

## Test plan

- [ ] Verify workflows compile successfully
- [ ] Check that workflow runs execute properly

🤖 Generated with [Claude Code](https://claude.ai/code)