### PR TITLE
feat: add dependabot burner

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A sample family of reusable [GitHub Agentic Workflows](https://github.github.com
 
 - [⚡ Daily Progress](docs/daily-progress.md) - Automated daily feature development following a structured roadmap
 - [📦 Daily Dependency Updater](docs/daily-dependency-updates.md) - Update dependencies and create pull requests
+- [:dependabot: Dependabot Burner](docs/dependabot-burner.md) - Bundle Dependabot PRs to reduce noise
 - [📖 Regular Documentation Update](docs/update-docs.md) - Update documentation automatically
 - [🏥 PR Fix](docs/pr-fix.md) - Analyze failing CI checks and implement fixes for pull requests
 - [🔎 Daily Adhoc QA](docs/daily-qa.md) - Perform adhoc explorative quality assurance tasks
@@ -38,7 +39,7 @@ Keep your agentic workflows up to date with the latest features and improvements
 Upgrade the AW engine version and update your workflows:
 
 ```bash
-gh extensions upgrade github/gh-aw # Update cli extensiô
+gh extensions upgrade github/gh-aw # Update cli extension
 gh aw upgrade  # Upgrade to latest gh aw engine version
 gh aw update   # Update added workflows
 ```

--- a/docs/dependabot-burner.md
+++ b/docs/dependabot-burner.md
@@ -1,0 +1,42 @@
+# :dependabot: Dependabot Burner
+
+> For an overview of all available workflows, see the [main README](../README.md).
+
+The [dependabot burner workflow](../workflows/dependabot-burner.md?plain=1) scans for open Dependabot pull requests and bundles them into issues by runtime and manifest file to reduce PR noise.
+
+## Installation
+
+```bash
+# Install the 'gh aw' extension
+gh extension install github/gh-aw
+
+# Add the Dependabot Burner workflow to your repository
+gh aw add-wizard githubnext/agentics/dependabot-burner
+```
+
+This walks you through adding the workflow to your repository. After merging the PR and syncing to main, you can start a run of this workflow immediately by running:
+
+```bash
+gh aw run dependabot-burner
+```
+
+## Configuration
+
+This workflow requires no configuration and works out of the box. You can edit it to adjust how updates are grouped and what goes into each bundle issue.
+
+After editing run `gh aw compile` to update the workflow and commit all changes to the default branch.
+
+## What it reads from GitHub
+
+- Pull requests and their metadata
+- Repository contents and dependency files
+
+## What it creates
+
+- Creates bundle issues summarizing related Dependabot PRs
+
+## Human in the loop
+
+- Review bundle issues for accuracy and completeness
+- Decide which PRs to merge or close based on the bundle
+- Adjust bundling logic if it is too noisy or too coarse

--- a/workflows/dependabot-burner.md
+++ b/workflows/dependabot-burner.md
@@ -1,0 +1,17 @@
+---
+on: weekly
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+tools:
+  github:
+safe-outputs:
+  create-issue:
+    title-prefix: '[dependabot-burner] '
+    max: 10
+---
+# Dependabot Burner
+
+- Find all open Dependabot PRs.
+- Create bundle issues, each for exactly **one runtime + one manifest file**.


### PR DESCRIPTION
- Introduces new "Dependabot Burner" workflow, aimed at reducing Dependabot PR noise by bundling related pull requests into issues.
- Fixes minor typo in the `README.md` for the CLI extension upgrade command.