### PR TITLE
fix: Use 'permissions: read-all' shorthand instead of 'all: read'

### DIFF
--- a/workflows/daily-perf-improver.md
+++ b/workflows/daily-perf-improver.md
@@ -12,8 +12,7 @@ on:
 
 timeout-minutes: 60
 
-permissions:
-  all: read
+permissions: read-all
 
 network: defaults
 

--- a/workflows/daily-test-improver.md
+++ b/workflows/daily-test-improver.md
@@ -11,8 +11,7 @@ on:
 
 timeout-minutes: 30
 
-permissions:
-  all: read
+permissions: read-all
 
 network: defaults
 


### PR DESCRIPTION


I was encountering the following error when running `gh aw compile` with the provided `.github/workflows/daily-test-improver.md`.

```
gh aw compile

.github/workflows/daily-test-improver.md:1:1: warning: Missing required permissions for github toolsets:
  - discussions: read (required by discussions)

To fix this, you can either:

Option 1: Add missing permissions to your workflow frontmatter:
permissions:
  discussions: read

See: https://github.com/github/gh-aw/blob/main/docs/src/content/docs/reference/permissions.md

Option 2: Reduce the required toolsets in your workflow:
Remove or adjust toolsets that require these permissions:
  - discussions
```

It seems like most other workflows are using the [`permissions: read-all` shorthand](https://github.github.com/gh-aw/reference/permissions/#shorthand-options). After modifying the workflow I was able to compile successfully. I haven't dug into the `gh-aw` code, but assume this is the preferred method for setting the read all permission; Updates other `all: read` call sites.

--- 

```
gh --version
gh version 2.87.0 (2026-02-18)
https://github.com/cli/cli/releases/tag/v2.87.0
```

```
gh extension list
NAME   REPO          VERSION
gh aw  github/gh-aw  v0.46.4
```