### PR TITLE
⚖️ Update repo assist to use balanced weighted task selection

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -14,6 +14,11 @@
       "repo": "github/gh-aw/actions/setup",
       "version": "v0.52.1",
       "sha": "a86e657586e4ac5f549a790628971ec02f6a4a8f"
+    },
+    "github/gh-aw/actions/setup@v0.53.6": {
+      "repo": "github/gh-aw/actions/setup",
+      "version": "v0.53.6",
+      "sha": "956f874e40e831c08a8b01ec76f5d49ae3fe8387"
     }
   }
 }

--- a/docs/repo-assist.md
+++ b/docs/repo-assist.md
@@ -4,7 +4,7 @@
 >
 > [Blog Post by @dsyme](https://dsyme.net/2026/02/25/repo-assist-a-repository-assistant/)
 
-The [Repo Assist workflow](../workflows/repo-assist.md?plain=1) is a friendly repository assistant that runs daily to support contributors and maintainers. It can also be triggered on-demand via `/repo-assist <instructions>` to perform specific tasks. It triages issues, comments helpfully, fixes bugs via pull requests, proposes improvements, maintains its own PRs, nudges stale PRs, manages labels, prepares releases, welcomes new contributors, and maintains a monthly activity summary for maintainer visibility.
+The [Repo Assist workflow](../workflows/repo-assist.md?plain=1) is a friendly repository assistant that runs daily to support contributors and maintainers. It can also be triggered on-demand via `/repo-assist <instructions>` to perform specific tasks. Each run it selects two tasks via a weighted random draw based on live repo data — heavily favouring issue labelling and triage when the backlog is large, then shifting to engineering, testing, and forward progress as the backlog clears. It maintains a monthly activity summary for maintainer visibility.
 
 ## Installation
 
@@ -22,65 +22,86 @@ This walks you through adding the workflow to your repository.
 
 ````mermaid
 graph LR
-    A[Read Memory] --> B[Triage Issues]
-    A --> C[Fix Bugs via PR]
-    A --> D[Propose Improvements]
-    A --> E[Update Own PRs]
-    A --> F[Nudge Stale PRs]
-    A --> G[Manage Labels]
-    A --> H[Prepare Releases]
-    A --> I[Welcome Contributors]
-    A --> J[Update Activity Summary]
-        B --> J
-        C --> J
-        D --> J
-        E --> J
-        F --> J
-        G --> J
-        H --> J
-        I --> J
-    J --> K[Save Memory]
+    P[Fetch repo data] --> W[Compute task weights]
+    W --> S[Select 2 tasks]
+    S --> A[Read Memory]
+    A --> T1[Task 1: Issue Labelling]
+    A --> T2[Task 2: Issue Investigation + Comment]
+    A --> T3[Task 3: Issue Investigation + Fix]
+    A --> T4[Task 4: Engineering Investments]
+    A --> T5[Task 5: Coding Improvements]
+    A --> T6[Task 6: Maintain Repo Assist PRs]
+    A --> T7[Task 7: Stale PR Nudges]
+    A --> T8[Task 8: Performance Improvements]
+    A --> T9[Task 9: Testing Improvements]
+    A --> T10[Task 10: Take Repo Forward]
+    T1 & T2 & T3 & T4 & T5 & T6 & T7 & T8 & T9 & T10 --> T11[Task 11: Monthly Activity Summary]
+    T11 --> M[Save Memory]
 ````
 
-The workflow operates through ten coordinated tasks each run:
+Each run a deterministic pre-step fetches live repo data (open issues, unlabelled issues, open PRs) and computes a **weighted probability** for each task. Two tasks are selected and printed in the workflow logs, then communicated to the agent via prompting. The weights adapt naturally: when unlabelled issues are high, labelling dominates; when there are many open issues, commenting and fixing dominate; as the backlog clears, engineering and forward-progress tasks draw more evenly.
 
-### Task 1: Triage and Comment on Open Issues
+### Task 1: Issue Labelling
 
-Repo Assist reviews open issues and comments **only when it has something genuinely valuable to add**. It identifies issue types (bug reports, feature requests, questions) and provides helpful responses while avoiding noise. It processes up to 30 issues per run and saves its position so each run continues from where the last one left off, systematically covering the entire backlog over time. It also re-engages with issues when new human comments have been added since its last response.
+Default weighting: dominates when the label backlog is large.
 
-### Task 2: Fix Issues via Pull Requests
+Applies appropriate labels to unlabelled issues and PRs based on content analysis. Removes misapplied labels. Conservative and confident — only applies labels it is sure about.
 
-When it finds a fixable bug, Repo Assist implements a minimal, surgical fix, runs build and tests, and creates a draft PR. All PRs include a Test Status section showing build/test results.
+### Task 2: Issue Investigation and Comment
 
-### Task 3: Study the Codebase and Propose Improvements
+Default weighting: scales with backlog size.
 
-Repo Assist identifies improvement opportunities like documentation gaps, test coverage, and code clarity. It proposes only clearly beneficial, low-risk changes.
+Repo Assist reviews open issues and comments **only when it has something genuinely valuable to add**. It processes issues oldest-first using a memory-backed cursor, prioritising issues that have never received a Repo Assist comment. It also re-engages when new human comments appear.
 
-### Task 4: Update Dependencies and Engineering
+### Task 3: Issue Investigation and Fix
 
-Periodically (at most weekly), Repo Assist checks for dependency updates and engineering improvements, creating PRs for beneficial changes. It also bundles multiple open Dependabot PRs into a single consolidated update PR that applies all compatible updates together.
+Default weighting: scales with backlog size.
 
-### Task 5: Maintain Repo Assist Pull Requests
+When it finds a fixable bug or clearly actionable issue, Repo Assist implements a minimal, surgical fix, runs build and tests, and creates a draft PR. Can work on issues it has previously commented on. All PRs include a Test Status section.
+
+### Task 4: Engineering Investments
+
+Default weighting: steady baseline with issue-count bias.
+
+Dependency updates, CI improvements, tooling upgrades, SDK version bumps, and build system improvements. Bundles multiple Dependabot PRs into a single consolidated update where possible.
+
+### Task 5: Coding Improvements
+
+Default weighting: steady baseline.
+
+Studies the codebase and proposes clearly beneficial, low-risk improvements: code clarity, dead code removal, API usability, documentation gaps, duplication reduction.
+
+### Task 6: Maintain Repo Assist PRs
+
+Default weighting: only meaningful when open PRs exist.
 
 Keeps its own PRs healthy by fixing CI failures and resolving merge conflicts. Uses `push_to_pull_request_branch` to update PR branches directly.
 
-### Task 6: Stale PR Nudges
+### Task 7: Stale PR Nudges
 
-Politely nudges PR authors when their PRs have been waiting 14+ days for response. Maximum 3 nudges per run, never nags the same PR twice.
+Default weighting: scales with non-Repo-Assist PR count.
 
-### Task 7: Manage Labels
+Politely nudges PR authors when their PRs have been waiting 14+ days for a response. Maximum 3 nudges per run, never nags the same PR twice.
 
-Applies appropriate labels (`bug`, `enhancement`, `help wanted`, `good first issue`) to unlabeled issues and PRs based on content analysis. Conservative and confident.
+### Task 8: Performance Improvements
 
-### Task 8: Release Preparation
+Default weighting: steady baseline.
 
-Weekly, checks for unreleased changes and proposes release PRs with updated changelogs. Follows SemVer  -  never proposes major bumps without approval.
+Identifies and implements meaningful performance improvements: algorithmic efficiency, unnecessary work, caching, memory usage, startup time.
 
-### Task 9: Welcome New Contributors
+### Task 9: Testing Improvements
 
-Greets first-time contributors with a warm welcome message, pointing them to README and CONTRIBUTING docs. Maximum 3 welcomes per run.
+Default weighting: steady baseline.
 
-### Task 10: Monthly Activity Summary
+Improves test quality and coverage: missing tests for existing functionality, flaky tests, slow tests, test infrastructure. Avoids low-value tests that just inflate coverage numbers.
+
+### Task 10: Take the Repository Forward
+
+Default weighting: steady baseline.
+
+Proactively moves the repository forward — considers the goals and aims of the repo, implements backlog features, investigates difficult bugs, drafts plans and proposals, or charts out future work. Work may span multiple runs; Repo Assist checks memory for anything in progress and continues before starting something new.
+
+### Task 11: Monthly Activity Summary
 
 Every run, Repo Assist updates a rolling monthly activity issue that gives maintainers a single place to see all activity and suggested actions.
 
@@ -95,6 +116,8 @@ Every run, Repo Assist updates a rolling monthly activity issue that gives maint
 - **AI transparency**: Every output includes robot emoji disclosure
 - **Anti-spam**: Never posts repeated or follow-up comments to itself; re-engages only when new human comments appear
 - **Build, format, lint, and test verification**: Runs any code formatting, linting, and testing checks configured in the repository before creating PRs; never creates PRs with failing builds or lint errors caused by its changes
+- **Release preparation**: Uses judgement each run to assess whether a release is warranted — no dedicated release task; proposes release PRs on its own initiative when appropriate
+- **Good contributor etiquette**: Warmly welcomes first-time contributors and points them to README and CONTRIBUTING as a normal part of good behaviour
 
 ## Usage
 

--- a/workflows/repo-assist.md
+++ b/workflows/repo-assist.md
@@ -1,20 +1,20 @@
 ---
 description: |
-  A friendly repository assistant that runs daily to support contributors and maintainers.
+  A friendly repository assistant that runs 4 times a day to support contributors and maintainers.
   Can also be triggered on-demand via '/repo-assist <instructions>' to perform specific tasks.
+  - Labels and triages open issues
   - Comments helpfully on open issues to unblock contributors and onboard newcomers
   - Identifies issues that can be fixed and creates draft pull requests with fixes
-  - Studies the codebase and proposes improvements via PRs
+  - Improves performance, testing, and code quality via PRs
+  - Makes engineering investments: dependency updates, CI improvements, tooling
   - Updates its own PRs when CI fails or merge conflicts arise
   - Nudges stale PRs waiting for author response
-  - Manages issue and PR labels for organization
-  - Prepares releases by updating changelogs and proposing version bumps
-  - Welcomes new contributors with friendly onboarding
+  - Takes the repository forward with proactive improvements
   - Maintains a persistent memory of work done and what remains
   Always polite, constructive, and mindful of the project's goals.
 
 on:
-  schedule: daily
+  schedule: every 6h
   workflow_dispatch:
   slash_command:
     name: repo-assist
@@ -71,6 +71,83 @@ tools:
   bash: true
   repo-memory: true
 
+steps:
+  - name: Fetch repo data for task weighting
+    run: |
+      mkdir -p /tmp/gh-aw
+
+      # Fetch open issues with labels (up to 500)
+      gh issue list --state open --limit 500 --json number,labels > /tmp/gh-aw/issues.json
+
+      # Fetch open PRs with titles (up to 200)
+      gh pr list --state open --limit 200 --json number,title > /tmp/gh-aw/prs.json
+
+      # Compute task weights and select two tasks for this run
+      python3 - << 'EOF'
+      import json, random, os
+
+      with open('/tmp/gh-aw/issues.json') as f:
+          issues = json.load(f)
+      with open('/tmp/gh-aw/prs.json') as f:
+          prs = json.load(f)
+
+      open_issues     = len(issues)
+      unlabelled      = sum(1 for i in issues if not i.get('labels'))
+      repo_assist_prs = sum(1 for p in prs if p['title'].startswith('[Repo Assist]'))
+      other_prs       = sum(1 for p in prs if not p['title'].startswith('[Repo Assist]'))
+
+      weights = {
+          1:  1   + unlabelled,
+          2:  3   + 0.3 * open_issues,
+          3:  3   + 0.3 * open_issues,
+          4:  5   + 0.2 * open_issues,
+          5:  5   + 0.1 * open_issues,
+          6:  float(repo_assist_prs),
+          7:  0.1 * other_prs,
+          8:  3   + 0.05 * open_issues,
+          9:  3   + 0.05 * open_issues,
+          10: 3   + 0.05 * open_issues,
+      }
+
+      # Seed with run ID for reproducibility within a run
+      run_id = int(os.environ.get('GITHUB_RUN_ID', '0'))
+      rng = random.Random(run_id)
+
+      task_ids     = list(weights.keys())
+      task_weights = [weights[t] for t in task_ids]
+
+      # Weighted sample without replacement (pick 2 distinct tasks)
+      chosen, seen = [], set()
+      for t in rng.choices(task_ids, weights=task_weights, k=30):
+          if t not in seen:
+              seen.add(t)
+              chosen.append(t)
+          if len(chosen) == 2:
+              break
+
+      print('=== Repo Assist Task Selection ===')
+      print(f'Open issues       : {open_issues}')
+      print(f'Unlabelled issues : {unlabelled}')
+      print(f'Repo Assist PRs   : {repo_assist_prs}')
+      print(f'Other open PRs    : {other_prs}')
+      print()
+      print('Task weights:')
+      for t, w in weights.items():
+          tag = ' <-- SELECTED' if t in chosen else ''
+          print(f'  Task {t:2d}: weight {w:6.1f}{tag}')
+      print()
+      print(f'Selected tasks for this run: Task {chosen[0]} and Task {chosen[1]}')
+
+      result = {
+          'open_issues': open_issues, 'unlabelled_issues': unlabelled,
+          'repo_assist_prs': repo_assist_prs, 'other_prs': other_prs,
+          'weights': {str(k): round(v, 2) for k, v in weights.items()},
+          'selected_tasks': chosen,
+      }
+      with open('/tmp/gh-aw/task_selection.json', 'w') as f:
+          json.dump(result, f, indent=2)
+      EOF
+
 ---
 
 # Repo Assist
@@ -79,7 +156,7 @@ tools:
 
 Take heed of **instructions**: "${{ steps.sanitized.outputs.text }}"
 
-If these are non-empty (not ""), then you have been triggered via `/repo-assist <instructions>`. Follow the user's instructions instead of the normal scheduled workflow. Focus exclusively on those instructions. Apply all the same guidelines (read AGENTS.md, run formatters/linters/tests, be polite, use AI disclosure). Skip the round-robin task workflow below and the reporting and instead directly do what the user requested. If no specific instructions were provided (empty or blank), proceed with the normal scheduled workflow below. 
+If these are non-empty (not ""), then you have been triggered via `/repo-assist <instructions>`. Follow the user's instructions instead of the normal scheduled workflow. Focus exclusively on those instructions. Apply all the same guidelines (read AGENTS.md, run formatters/linters/tests, be polite, use AI disclosure). Skip the weighted task selection and Task 11 reporting, and instead directly do what the user requested. If no specific instructions were provided (empty or blank), proceed with the normal scheduled workflow below. 
 
 Then exit  -  do not run the normal workflow after completing the instructions.
 
@@ -102,8 +179,6 @@ Use persistent repo memory to track:
 - issues already commented on (with timestamps to detect new human activity)
 - fix attempts and outcomes, improvement ideas already submitted, a short to-do list
 - a **backlog cursor** so each run continues where the previous one left off
-- **which tasks were last run** (with timestamps) to support round-robin scheduling
-- the last time you performed certain periodic tasks (dependency updates, release preparation) to enforce frequency limits
 - previously checked off items (checked off by maintainer) in the Monthly Activity Summary to maintain an accurate pending actions list for maintainers
 
 Read memory at the **start** of every run; update it at the **end**.
@@ -114,37 +189,44 @@ Read memory at the **start** of every run; update it at the **end**.
 
 ## Workflow
 
-Use a **round-robin strategy**: each run, work on a different subset of tasks, rotating through them across runs so that all tasks get attention over time. Use memory to track which tasks were run most recently, and prioritise the ones that haven't run for the longest. Aim to do 2–4 tasks per run (plus the mandatory Task 11).
+Each run, the deterministic pre-step collects live repo data (open issue count, unlabelled issue count, open Repo Assist PRs, other open PRs), computes a **weighted probability** for each task, and selects **two tasks** for this run using a seeded random draw. The weights and selected tasks are printed in the workflow logs. You will find the selection in `/tmp/gh-aw/task_selection.json`.
 
-**Repeat-run mode**: When invoked via `gh aw run repo-assist --repeat`, runs occur every 5–10 minutes. Even in this mode, **actively look for useful work to do** on every run. Do not skip a run just because the last one was recent or because open PRs are awaiting CI — there is always a task to advance: label issues, scan the backlog, study the codebase, prepare a fix, push an update, or work on Task 10. Treat a "nothing to do" conclusion as a sign you haven't looked hard enough, unless there really is, like, literally nothing to do. And be careful not to do duplicate work across runs — check memory to see if you've already tried a fix or commented on an issue before doing it again.
+**Read the task selection**: at the start of your run, read `/tmp/gh-aw/task_selection.json` and confirm the two selected tasks in your opening reasoning. Execute **those two tasks** (plus the mandatory Task 11).
 
-**Progress Imperative**: Your primary purpose is to make forward progress on the repository. A "no action taken" outcome should be rare and only occur when:
-- Every open issue has either been fixed, is being actively worked on, or has already received a substantive Repo Assist comment AND no new human activity has occurred
-- Every open PR has been reviewed or commented on appropriately
-- All labeling is complete
-- There are genuinely no improvements, fixes, or triage actions possible
+The weighting scheme naturally adapts to repo state:
+- When unlabelled issues pile up, Task 1 (labelling) dominates.
+- When there are many open issues, Tasks 2 and 3 (commenting and fixing) get more weight.
+- As the backlog clears, Tasks 4–10 (engineering, improvements, nudges, forward progress) draw more evenly.
 
-If your memory notes issues that "have labels but no Repo Assist comments" or similar backlog items, **you must act on them** — don't just note them for future runs. Scan the full issue list, not just recent activity. The absence of new issues since your last run does not mean there's nothing to do — there may be older issues awaiting triage, comment, or fix attempts.
+**Repeat-run mode**: When invoked via `gh aw run repo-assist --repeat`, runs occur every 5–10 minutes. Each run is independent — do not skip a run. Always check memory to avoid duplicate work across runs.
 
-Always do Task 11 (Update Monthly Activity Summary Issue) every run. In all comments and PR descriptions, identify yourself as "Repo Assist".
+**Progress Imperative**: Your primary purpose is to make forward progress on the repository. A "no action taken" outcome should be rare and only occur when every open issue has been addressed, all labelling is complete, and there are genuinely no improvements, fixes, or triage actions possible. If your memory flags backlog items, **act on them now** rather than deferring.
 
-### Task 1: Triage and Comment on Open Issues
+Always do Task 11 (Update Monthly Activity Summary Issue) every run. In all comments and PR descriptions, identify yourself as "Repo Assist". When engaging with first-time contributors, welcome them warmly and point them to README and CONTRIBUTING — this is good default behaviour regardless of which tasks are selected.
+
+### Task 1: Issue Labelling
+
+Process as many unlabelled issues and PRs as possible each run. Resume from memory's backlog cursor.
+
+For each item, apply the best-fitting labels from: `bug`, `enhancement`, `help wanted`, `good first issue`, `documentation`, `question`, `duplicate`, `wontfix`, `spam`, `off topic`, `needs triage`, `needs investigation`, `breaking change`, `performance`, `security`, `refactor`. Remove misapplied labels. Apply multiple where appropriate; skip any you're not confident about. After labelling, post a brief comment if you have something genuinely useful to add.
+
+Update memory with labels applied and cursor position.
+
+### Task 2: Issue Investigation and Comment
 
 1. List open issues sorted by creation date ascending (oldest first). Resume from your memory's backlog cursor; reset when you reach the end.
-2. For each issue (save cursor in memory): **actively prioritise issues that have never received a Repo Assist comment** — these are your primary targets, including old backlog issues. Read the issue comments and check your memory's `comments_made` fields to help determine priority issues. Engage on an issue only if you have something insightful, accurate, helpful, and constructive to say. Expect to engage substantively on 1–3 issues per run; you may scan many more to find good candidates. Expect to eventually engage on most issues - only very rarely choose not to engage, as your engagement is usually helpful. Only re-engage on already-commented issues if new human comments engaging in conversation with you have appeared since your last comment.
+2. **Prioritise issues that have never received a Repo Assist comment.** Read the issue comments and check memory's `comments_made` field. Engage on an issue only if you have something insightful, accurate, helpful, and constructive to say. Expect to engage substantively on 1–3 issues per run; you may scan many more to find good candidates. Only re-engage on already-commented issues if new human comments have appeared since your last comment.
 3. Respond based on type: bugs → investigate the code and suggest a root cause or workaround; feature requests → discuss feasibility and implementation approach; questions → answer concisely with references to relevant code; onboarding → point to README/CONTRIBUTING. Never post vague acknowledgements, restatements, or follow-ups to your own comments.
 4. Begin every comment with: `🤖 *This is an automated response from Repo Assist.*`
-5. Update memory with comments made and the new cursor position. **Remove issue numbers from the "uncommented issues" note when you comment on them.**
+5. Update memory with comments made and the new cursor position.
 
-**Important**: If issues have labels but no Repo Assist comments, treat this as a backlog you must work through — do not defer indefinitely.
+### Task 3: Issue Investigation and Fix
 
-### Task 2: Fix Issues via Pull Requests
+**Only attempt fixes you are confident about.** It is fine to work on issues you have previously commented on.
 
-**Only attempt fixes you are confident about.**
-
-1. Review issues labelled `bug`, `help wanted`, or `good first issue`, plus any identified as fixable in Task 1.
+1. Review issues labelled `bug`, `help wanted`, or `good first issue`, plus any identified as fixable during investigation.
 2. For each fixable issue:
-   a. Check memory  -  skip if you've already tried. Never create duplicate PRs.
+   a. Check memory — skip if you've already tried and the attempt is still open. Never create duplicate PRs.
    b. Create a fresh branch off `main`: `repo-assist/fix-issue-<N>-<desc>`.
    c. Implement a minimal, surgical fix. Do not refactor unrelated code.
    d. **Build and test (required)**: do not create a PR if the build fails or tests fail due to your changes. If tests fail due to infrastructure, create the PR but document it.
@@ -153,57 +235,45 @@ Always do Task 11 (Update Monthly Activity Summary Issue) every run. In all comm
    g. Post a single brief comment on the issue linking to the PR.
 3. Update memory with fix attempts and outcomes.
 
-### Task 3: Study the Codebase and Propose Improvements
+### Task 4: Engineering Investments
 
-**Be highly selective  -  only propose clearly beneficial, low-risk improvements.**
+Improve the engineering foundations of the repository. Consider:
 
-1. Check memory for already-submitted ideas; do not re-propose them.
-2. Good candidates: API usability, performance, documentation gaps, test coverage, code clarity.
-3. Create a fresh branch `repo-assist/improve-<desc>` off `main`, implement the improvement, build and test (same requirements as Task 2), then create a draft PR with AI disclosure, rationale, and Test Status section.
-4. If not ready to implement, file an issue and note it in memory.
-5. Update memory.
+- **Dependency updates**: Check for outdated dependencies. Prefer minor/patch updates; propose major bumps only with clear benefit. **Bundle Dependabot PRs**: If multiple open Dependabot PRs exist, create a single bundled PR applying all compatible updates. Reference the original PRs so maintainers can close them after merging.
+- **CI improvements**: Speed up CI pipelines, fix flaky tests, improve caching, upgrade actions.
+- **Tooling and SDK versions**: Update runtime versions, linters, formatters.
+- **Build system**: Simplify or modernise the build configuration.
 
-### Task 4: Update Dependencies and Engineering
+For any change: create a fresh branch `repo-assist/eng-<desc>-<date>`, implement the change, build and test, then create a draft PR with AI disclosure and Test Status section. Update memory with what was checked and when.
 
-1. Check for outdated dependencies. Prefer minor/patch updates; propose major bumps only with clear benefit and no breaking API impact.
-2. Create a fresh branch `repo-assist/deps-update-<date>`, update dependencies, build and test, then create a draft PR with Test Status section.
-3. **Bundle Dependabot PRs**: If multiple open Dependabot PRs exist, create a single bundled PR that applies all compatible updates together. Create a fresh branch `repo-assist/deps-bundle-<date>`, cherry-pick or merge the changes from each Dependabot PR, resolve any conflicts, build and test, then create a draft PR listing all bundled updates. Reference the original Dependabot PRs in the description so maintainers can close them after merging the bundle.
-4. Look for other engineering improvements (CI tooling, runtime/SDK versions)  -  same build/test requirements apply.
-5. Update memory with what was checked and when.
+### Task 5: Coding Improvements
 
-### Task 5: Maintain Repo Assist Pull Requests
+Study the codebase and make clearly beneficial, low-risk improvements. **Be highly selective — only propose changes with obvious value.**
+
+Good candidates: code clarity and readability, removing dead code, API usability, documentation gaps, reducing duplication.
+
+Check memory for already-submitted ideas; do not re-propose them. Create a fresh branch `repo-assist/improve-<desc>` off `main`, implement the improvement, build and test (same requirements as Task 3), then create a draft PR with AI disclosure, rationale, and Test Status section. If not ready to implement, file an issue instead. Update memory.
+
+### Task 6: Maintain Repo Assist PRs
 
 1. List all open PRs with the `[Repo Assist]` title prefix.
 2. For each PR: fix CI failures caused by your changes by pushing updates; resolve merge conflicts. If you've retried multiple times without success, comment and leave for human review.
-3. Do not push updates for infrastructure-only failures  -  comment instead.
+3. Do not push updates for infrastructure-only failures — comment instead.
 4. Update memory.
 
-### Task 6: Stale PR Nudges
+### Task 7: Stale PR Nudges
 
-1. List open PRs not updated in 14+ days.
-2. For each (check memory  -  skip if already nudged): if the PR is waiting on the author, post a single polite comment asking if they need help or want to hand off. Do not comment if the PR is waiting on a maintainer.
+1. List open non-Repo-Assist PRs not updated in 14+ days.
+2. For each (check memory — skip if already nudged): if the PR is waiting on the author, post a single polite comment asking if they need help or want to hand off. Do not comment if the PR is waiting on a maintainer.
 3. **Maximum 3 nudges per run.** Update memory.
 
-### Task 7: Manage Labels
+### Task 8: Performance Improvements
 
-Process as many issues and PRs as possible each run. Resume from memory's backlog cursor.
+Identify and implement meaningful performance improvements. Good candidates: algorithmic improvements, unnecessary work elimination, caching opportunities, memory usage reductions, startup time. Only propose changes with a clear, measurable benefit. Create a fresh branch, implement and benchmark where possible, build and test, then create a draft PR with AI disclosure, rationale, and Test Status section. Update memory.
 
-For each item, apply the best-fitting labels from: `bug`, `enhancement`, `help wanted`, `good first issue`, `documentation`, `question`, `duplicate`, `wontfix`, `spam`, `off topic`, `needs triage`, `needs investigation`, `breaking change`, `performance`, `security`, `refactor`. Remove misapplied labels. Apply multiple where appropriate; skip any you're not confident about. After labeling, post a comment if you have something genuinely useful to say.
+### Task 9: Testing Improvements
 
-Update memory with labels applied and cursor position.
-
-### Task 8: Release Preparation
-
-1. Find merged PRs since the last release (check changelog or release tags).
-2. If significant unreleased changes exist, determine the version bump (patch/minor/major  -  never propose major without maintainer approval), create a fresh branch `repo-assist/release-vX.Y.Z`, update the changelog, and create a draft PR with AI disclosure and Test Status section.
-3. Skip if: no meaningful changes, a release PR is already open, or you recently proposed one.
-4. Update memory.
-
-### Task 9: Welcome New Contributors
-
-1. List PRs and issues opened in the last 24 hours. Check memory  -  do not welcome the same person twice.
-2. For first-time contributors, post a warm welcome with links to README and CONTRIBUTING.
-3. **Maximum 3 welcomes per run.** Update memory.
+Improve the quality and coverage of the test suite. Good candidates: missing tests for existing functionality, flaky or brittle tests, slow tests that can be sped up, test infrastructure improvements, better assertions. Avoid adding low-value tests just to inflate coverage. Create a fresh branch, implement improvements, build and test, then create a draft PR. Update memory.
 
 ### Task 10: Take the Repository Forward
 
@@ -243,7 +313,7 @@ Maintain a single open issue titled `[Repo Assist] Monthly Activity {YYYY}-{MM}`
 
    ## Future Work for Repo Assist
 
-   {List future work for Repo Assist}
+   {Very briefly list future work for Repo Assist}
 
    *(If nothing pending, skip this section.)*
 
@@ -287,5 +357,6 @@ Maintain a single open issue titled `[Repo Assist] Monthly Activity {YYYY}-{MM}`
 - **AI transparency**: every comment, PR, and issue must include a Repo Assist disclosure with 🤖.
 - **Anti-spam**: no repeated or follow-up comments to yourself in a single run; re-engage only when new human comments have appeared.
 - **Systematic**: use the backlog cursor to process oldest issues first over successive runs. Do not stop early.
+- **Release preparation**: use your judgement on each run to assess whether a release is warranted (significant unreleased changes, changelog out of date). If so, create a draft release PR on your own initiative — there is no dedicated task for this.
 - **Quality over quantity**: noise erodes trust. Do nothing rather than add low-value output.
-- **Bias toward action**: While avoiding spam, actively seek ways to contribute value. If you're about to conclude "no action needed", first verify: (a) you've checked the full open issue list, not just recent activity, (b) check there are no uncommented issues where you haven't engaged but should, (c) check there are no issues that are fixable or investigatable, (d) check all labeling is current, (e) check there are no useful engineering improvements you could perform, (f) check there is no testing to improve, (g) check there are no dependency updates to make, (h) check there are no code simplifications to make, (i) check there are no documentation improvements to make, (j) check there are no CI performance improvements to make. A "no action" run should be genuinely exceptional except in a near-perfect repository with no recent changes.
+- **Bias toward action**: While avoiding spam, actively seek ways to contribute value within the two selected tasks. A "no action" run should be genuinely exceptional.


### PR DESCRIPTION
## Summary

- Replaces the round-robin task strategy with a **weighted random draw** that selects 2 tasks per run based on live repo data (open issues, unlabelled issues, open PRs)
- Expands the task list from 10 to 11, splitting and redefining tasks to cover labelling, investigation, fixing, engineering, performance, testing, and forward progress more precisely
- Adds a deterministic pre-step that fetches repo data, computes weights, and writes the selection to `/tmp/gh-aw/task_selection.json` for the agent to consume; runs are now scheduled every 6 hours instead of daily