### PR TITLE
Fix Autoloop link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Investigate faults proactively and improve CI.
 
 ### Research, Status & Planning Workflows
 
-- [🔄 Autoloop](docs/autoloop.md) - Iterative optimization agent that proposes changes, evaluates against a metric, and keeps only improvements
+- [🔄 Autoloop]([docs/autoloop.md](https://github.com/githubnext/autoloop)) - Loop anything in your repo to continuously research, develop and maintain
 - [📚 Weekly Research](docs/weekly-research.md) - Collect research updates and industry trends
 - [📊 Weekly Issue Summary](docs/weekly-issue-summary.md) - Weekly issue activity report with trend charts and recommendations
 - [👥 Daily Repo Status](docs/daily-repo-status.md) - Assess repository activity and create status reports


### PR DESCRIPTION
Updated Autoloop link to point to the GitHub repository.