### PR TITLE
fix: update Discord channel reference for feedback sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,4 +134,4 @@ This automatically updates agent files, applies codemods, updates actions versio
 
 ## 💬 Share Feedback
 
-Is your favorite agentic workflow not here? Do you have an idea for a new one? Clone this repo and explore, create! Tell us about it! You can file bugs and feature requests as issues in this repository and share your thoughts in the `#continuous-ai` channel in the [GitHub Next Discord](https://gh.io/next-discord).
+Is your favorite agentic workflow not here? Do you have an idea for a new one? Clone this repo and explore, create! Tell us about it! You can file bugs and feature requests as issues in this repository and share your thoughts in the `#agentic-workflows` channel in the [GitHub Next Discord](https://gh.io/next-discord).


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

This pull request makes a minor update to the `README.md` file, clarifying the correct Discord channel for feedback and discussion. The channel reference was changed from `#continuous-ai` to `#agentic-workflows`.