### PR TITLE
fix: add dependabot to ai-moderator skip-bots

### DIFF
--- a/workflows/ai-moderator.md
+++ b/workflows/ai-moderator.md
@@ -13,7 +13,7 @@ on:
     types: [opened]
     forks: "*"
   skip-roles: [admin, maintainer, write, triage]
-  skip-bots: [github-actions, copilot]
+  skip-bots: [github-actions, copilot, dependabot]
 
 rate-limit:
   max: 5


### PR DESCRIPTION
Dependabot uses GitHub App permissions (`permission: none`), so the role-based `skip-roles` check doesn't catch it. This adds `dependabot` to the `skip-bots` list alongside `github-actions` and `copilot`  to prevent unnecessary AI moderator runs on Dependabot PRs.