### PR TITLE
fix: mermaid diagram parsing error with special characters

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -22,11 +22,11 @@ This walks you through adding the workflow to your repository.
 
 ```mermaid
 graph LR
-    A[/plan Command] --> B[Analyze Issue/Discussion]
-    B --> C[Break Down Work]
-    C --> D[Create Sub-Issues]
-    D --> E[Link to Parent]
-    E --> F[Assign to Copilot]
+    A["/plan Command"] --> B["Analyze Issue/Discussion"]
+    B --> C["Break Down Work"]
+    C --> D["Create Sub-Issues"]
+    D --> E["Link to Parent"]
+    E --> F["Assign to Copilot"]
 ```
 
 Each sub-issue includes a clear title, objective, context, approach, specific files to modify, and acceptance criteria.


### PR DESCRIPTION
Fix Mermaid diagram rendering issue caused by unescaped node labels.

- Wrap all node labels in double quotes
- Prevent parsing errors with special characters like `/`
- Improve diagram reliability in GitHub markdown
