### PR TITLE
docs(readme): add AgentMeter log-watcher community AW

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Investigate faults proactively and improve CI.
 - [🏥 CI Doctor](docs/ci-doctor.md) - Monitor CI workflows and investigate failures automatically
 - [🚀 CI Coach](docs/ci-coach.md) - Optimize CI workflows for speed and cost efficiency
 - [💰 Cost Tracker](docs/cost-tracker.md) - Post per-run agent spend summaries on pull requests using token-usage.jsonl from gh-aw's firewall
+- [🔍 Log Watcher](https://github.com/AgentMeter/agentmeter-action/blob/main/workflows/log-watcher.md) - Diagnose agent run failures by scanning logs for errors, retry loops, rate limits, and token anomalies, then posting a health report on the associated PR or issue _(community - maintained in [AgentMeter/agentmeter-action](https://github.com/AgentMeter/agentmeter-action))_
 
 ### Code Review Workflows
 


### PR DESCRIPTION
Adds a community workflow entry in the Fault Analysis section for [Log Watcher](https://github.com/AgentMeter/agentmeter-action/blob/main/workflows/log-watcher.md), maintained in [AgentMeter/agentmeter-action](https://github.com/AgentMeter/agentmeter-action).

The workflow picks up the `agent-artifacts` artifact written by gh-aw's firewall, scans logs for error/exception/fatal signals, retry loops, timeout and rate-limit patterns, and token anomalies, then posts a diagnostic health report on the associated PR or creates a diagnosis issue.

This was requested in PR #327 (implemented the original Cost Tracker workflow) - following the same pattern of hosting community-maintained workflows in the author's own repo and linking from the README.

Workflow file: https://github.com/AgentMeter/agentmeter-action/blob/main/workflows/log-watcher.md