### PR TITLE
Update documentation for adding workflow in doc-updater

### DIFF
--- a/docs/doc-updater.md
+++ b/docs/doc-updater.md
@@ -13,7 +13,7 @@ The [Daily Documentation Updater workflow](../workflows/doc-updater.md?plain=1) 
 gh extension install github/gh-aw
 
 # Add the workflow to your repository
-gh aw add-wizard githubnext/agentics/doc-updater
+gh aw add githubnext/agentics/doc-updater
 ```
 
 This walks you through adding the workflow to your repository.


### PR DESCRIPTION
This pull request updates the documentation for adding the Daily Documentation Updater workflow. The command for adding the workflow has been corrected to use the appropriate `gh aw add` syntax.

- Documentation update:
  * In `docs/doc-updater.md`, replaced the incorrect `gh aw add-wizard` command with the correct `gh aw add` command for adding the workflow.Updated command to add the workflow in the documentation.